### PR TITLE
Fix document.ready syntax usage

### DIFF
--- a/movies/static/movies/app.js
+++ b/movies/static/movies/app.js
@@ -38,5 +38,5 @@ function main() {
     modal();
 }
 
-$(document).ready(main());
+$(document).ready(main);
 


### PR DESCRIPTION
## Summary
- ensure `main` callback is passed correctly to `$(document).ready`

## Testing
- `python manage.py test` *(fails: module 'collections' has no attribute 'Iterator')*
- `python manage.py runserver 0.0.0.0:8000` *(fails: module 'collections' has no attribute 'Iterator')*

------
https://chatgpt.com/codex/tasks/task_e_684769fa52348325b7cda893ec6ea1f8